### PR TITLE
Comment out the second docker exec

### DIFF
--- a/wrappers/yarn.sh
+++ b/wrappers/yarn.sh
@@ -20,8 +20,8 @@ if docker ps -a | awk '{print $NF}' | grep -w "$APP_CONTAINER" > /dev/null 2>&1;
     docker exec \
       "$APP_CONTAINER" \
       yarn "$@"
-    docker exec \
-      "$APP_CONTAINER" \
+    #docker exec \
+      #"$APP_CONTAINER" \
       #chown -R "$(id -u)":"$(id -g)" node_modules package.json yarn.lock
   else
     echo -e "${RED}Unrecognized command: ${NC}$1"


### PR DESCRIPTION
# Issue
Run the `yarn` wrapper throws a error

# Solution
Comment out the second docker `exec`

